### PR TITLE
Paginate Registry applications and store in cache

### DIFF
--- a/src/main/scala/io/flow/proxy/Controller.scala
+++ b/src/main/scala/io/flow/proxy/Controller.scala
@@ -51,6 +51,13 @@ case class Controller() extends io.flow.build.Controller {
       }
 
       val cache = RegistryApplicationCache(registryClient)
+
+      /**
+        * Pre-Load Cache - Paginate through Registry applications (100 results/page) and load into cache
+        * If cache is not pre-loaded, it will be loaded on first attempt to 'get'
+        */
+      cache.loadCache(100, 0)
+
       build(services, version, "development") { service =>
         s"http://$DevelopmentHostname:${cache.externalPort(service.name.toLowerCase)}"
       }

--- a/src/main/scala/io/flow/proxy/Controller.scala
+++ b/src/main/scala/io/flow/proxy/Controller.scala
@@ -52,12 +52,6 @@ case class Controller() extends io.flow.build.Controller {
 
       val cache = RegistryApplicationCache(registryClient)
 
-      /**
-        * Pre-Load Cache - Paginate through Registry applications (100 results/page) and load into cache
-        * If cache is not pre-loaded, it will be loaded on first attempt to 'get'
-        */
-      cache.loadCache(100, 0)
-
       build(services, version, "development") { service =>
         s"http://$DevelopmentHostname:${cache.externalPort(service.name.toLowerCase)}"
       }

--- a/src/main/scala/io/flow/proxy/RegistryApplicationCache.scala
+++ b/src/main/scala/io/flow/proxy/RegistryApplicationCache.scala
@@ -2,7 +2,6 @@ package io.flow.proxy
 
 import io.flow.registry.v0.{Client => RegistryClient}
 import io.flow.registry.v0.models.Application
-
 import scala.annotation.tailrec
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration.Duration
@@ -22,7 +21,6 @@ private[proxy] case class RegistryApplicationCache(client: RegistryClient)(impli
     * @param name Application name in registry
     */
   def get(name: String): Option[Application] = {
-    println(cache)
     cache.getOrElse(
       name, {
         //attempt to load/reload cache and 'get' again, otherwise, fail


### PR DESCRIPTION
Example of 2 `loadCache` methods that paginate and store all Registry applications in the cache.

**loadCache**: Tail Recursive method to load paginated Registry applications to cache
**loadCacheWithFold** (not used)
