### PR TITLE
Add linter for *_error models

### DIFF
--- a/src/main/scala/io/flow/lint/Lint.scala
+++ b/src/main/scala/io/flow/lint/Lint.scala
@@ -21,6 +21,7 @@ object Lint {
     linters.CommonFieldTypes,
     linters.CommonParameterTypes,
     linters.CommonParametersHaveNoDescriptions,
+    linters.ErrorModels,
     linters.EventModels,
     linters.ExpandableUnionsAreConsistent,
     linters.Get,

--- a/src/main/scala/io/flow/lint/linters/ErrorModels.scala
+++ b/src/main/scala/io/flow/lint/linters/ErrorModels.scala
@@ -1,0 +1,66 @@
+package io.flow.lint.linters
+
+import io.flow.lint.Linter
+import com.bryzek.apidoc.spec.v0.models.{Field, Model, Service}
+
+/**
+  * For error models (those with an error_id field in position 1), validate:
+  * 
+  *   a. second field is timestamp
+  *   b. if 'organization', next
+  *   c. if 'number', next
+  */
+case object ErrorModels extends Linter with Helpers {
+
+  override def validate(service: Service): Seq[String] = {
+    service.models.filter(isError(_)).flatMap(validateModel(_))
+  }
+
+  def isError(model: Model): Boolean = {
+    model.name.endsWith("_error")
+  }
+
+  def validateModel(model: Model): Seq[String] = {
+    val fieldNames = model.fields.map(_.name)
+    fieldNames match {
+      case "code" :: "messages" :: rest => {
+        val codeErrors = model.fields(0).`type` == "string" match {
+          case true => Nil
+          case false => Seq("error models require the type of the 'code' field to be 'string'")
+        }
+
+        val messagesErrors = model.fields(1).`type` == "[string]" match {
+          case true => Nil
+          case false => Seq("error models require the type of the 'messages' field to be '[string]'")
+        }
+
+        codeErrors ++ messagesErrors
+      }
+
+      case _ => {
+        val codeErrors = fieldNames.contains("code") match {
+          case false => Seq("error models require a field named 'code'")
+          case true => {
+            fieldNames match {
+              case "code" :: rest => Nil
+              case _ => Seq("error models require the the first field to be named 'code'")
+            }
+          }
+        }
+
+        val messagesErrors = fieldNames.contains("messages") match {
+          case false => Seq("error models require a field named 'messages'")
+          case true => {
+            fieldNames match {
+              case f :: "messages" :: rest => Nil
+              case _ => Seq("error models require the the second field to be named 'messages'")
+            }
+          }
+        }
+
+        codeErrors ++ messagesErrors
+      }
+    }
+  }
+  
+}

--- a/src/main/scala/io/flow/lint/linters/StandardResponse.scala
+++ b/src/main/scala/io/flow/lint/linters/StandardResponse.scala
@@ -15,7 +15,6 @@ import com.bryzek.apidoc.spec.v0.models.{ResponseCodeInt, ResponseCodeOption, Re
   * 
   *   - 204 - verify type: unit
   *   - 401 - verify type: unit, description: "unauthorized request"
-  *   - 422 - verify type: "io.flow.error.v0.*"
   */
 case object StandardResponse extends Linter with Helpers {
 
@@ -93,7 +92,7 @@ case object StandardResponse extends Linter with Helpers {
         n match {
           case 204 => compare(resource, operation, response, "unit")
           case 401 => compare(resource, operation, response, "unit")
-          case 422 => compare(resource, operation, response, "io.flow.error.v0.*")
+          case 422 => compare(resource, operation, response, "*_error")
           case _ => Nil
         }
       }
@@ -122,7 +121,7 @@ case object StandardResponse extends Linter with Helpers {
   ): Boolean = {
     typ == pattern match {
       case true => true
-      case false => pattern.endsWith("*") && typ.startsWith(pattern.dropRight(1))
+      case false => pattern.startsWith("*") && typ.endsWith(pattern.drop(1))
     }
   }
 }

--- a/src/test/scala/io/flow/lint/ErrorModelsSpec.scala
+++ b/src/test/scala/io/flow/lint/ErrorModelsSpec.scala
@@ -1,0 +1,56 @@
+package io.flow.lint
+
+import com.bryzek.apidoc.spec.v0.models._
+import org.scalatest.{FunSpec, Matchers}
+
+class ErrorModelsSpec extends FunSpec with Matchers {
+
+  val linter = linters.ErrorModels
+
+  val code = Services.buildField("code")
+  val messages = Services.buildField("messages", "[string]")
+
+  def buildService(
+    fields: Seq[Field]
+  ): Service = {
+    Services.Base.copy(
+      models = Seq(
+        Services.buildModel(
+          name = "test_error",
+          fields = fields
+        )
+      )
+    )
+  }
+
+  it("fields must start with code, messages") {
+    linter.validate(buildService(Seq(code, messages))) should be(Nil)
+
+    linter.validate(buildService(Nil)) should be(Seq(
+      "error models require a field named 'code'",
+      "error models require a field named 'messages'"
+    ))
+
+    linter.validate(buildService(Seq(messages))) should be(Seq(
+      "error models require a field named 'code'",
+      "error models require the the second field to be named 'messages'"
+    ))
+    linter.validate(buildService(Seq(code))) should be(Seq(
+      "error models require a field named 'messages'"
+    ))
+    linter.validate(buildService(Seq(messages, code))) should be(Seq(
+      "error models require the the first field to be named 'code'",
+      "error models require the the second field to be named 'messages'"
+    ))
+  }
+
+  it("validated type of 'code' field") {
+    linter.validate(buildService(Seq(code.copy(`type` = "integer"), messages))) should be(Seq(
+      "error models require the type of the 'code' field to be 'string'"
+    ))
+    linter.validate(buildService(Seq(code, messages.copy(`type` = "integer")))) should be(Seq(
+      "error models require the type of the 'messages' field to be '[string]'"
+    ))
+  }
+
+}

--- a/src/test/scala/io/flow/lint/StandardResponseSpec.scala
+++ b/src/test/scala/io/flow/lint/StandardResponseSpec.scala
@@ -154,7 +154,7 @@ class StandardResponseSpec extends FunSpec with Matchers {
   }
 
   it("Handles invalid error types") {
-    Seq("error", "[error]").foreach { typ =>
+    Seq("ordererrors", "error", "[generic_error]").foreach { typ =>
       linter.validate(
         buildService(
           Method.Post,
@@ -166,14 +166,21 @@ class StandardResponseSpec extends FunSpec with Matchers {
         )
       ) should be(
         Seq(
-          s"Resource organizations POST /organizations Response 422: response must be of type io.flow.error.v0.* and not $typ"
+          s"Resource organizations POST /organizations Response 422: response must be of type *_error and not $typ"
         )
       )
     }
   }
 
   it("Handles valid error types") {
-    Seq("io.flow.error.v0.models.validation_error", "io.flow.error.v0.models.order_error", "io.flow.error.v0.unions.order_error").foreach { typ =>
+    Seq(
+      "order_error",
+      "generic_error",
+      "card_error",
+      "io.flow.error.v0.models.validation_error",
+      "io.flow.error.v0.models.order_error",
+      "io.flow.error.v0.unions.order_error"
+    ).foreach { typ =>
       linter.validate(
         buildService(
           Method.Post,


### PR DESCRIPTION
- Any mode ending w/ _error must have fields:
    - code: string
    - messages: [string]