### PR TITLE
revert change to host

### DIFF
--- a/src/main/scala/io/flow/build/Environment.scala
+++ b/src/main/scala/io/flow/build/Environment.scala
@@ -13,7 +13,7 @@ object ApibuilderConfig {
 
   private[this] val DefaultApibuilderProfile = ApibuilderProfile(
     name = "default",
-    baseUrl = "https://app.apibuilder.io",
+    baseUrl = "https://api.apibuilder.io",
     token = None
   )
 


### PR DESCRIPTION
not sure if anything changed "behind the scenes", but  when reverting this back to using `api`, it ran successfully when triggered locally.