### PR TITLE
Add ignore case to error models linter

### DIFF
--- a/src/main/scala/io/flow/lint/linters/ErrorModels.scala
+++ b/src/main/scala/io/flow/lint/linters/ErrorModels.scala
@@ -13,7 +13,10 @@ import io.apibuilder.spec.v0.models.{Field, Model, Service}
 case object ErrorModels extends Linter with Helpers {
 
   override def validate(service: Service): Seq[String] = {
-    service.models.filter(isError(_)).flatMap(validateModel(service, _))
+    service.models
+      .filter(isError(_))
+      .filter(e => !ignored(e.attributes, "error_models"))
+      .flatMap(validateModel(service, _))
   }
 
   def isError(model: Model): Boolean = {

--- a/src/test/scala/io/flow/lint/ErrorModelsSpec.scala
+++ b/src/test/scala/io/flow/lint/ErrorModelsSpec.scala
@@ -2,6 +2,7 @@ package io.flow.lint
 
 import io.apibuilder.spec.v0.models._
 import org.scalatest.{FunSpec, Matchers}
+import play.api.libs.json.Json
 
 class ErrorModelsSpec extends FunSpec with Matchers {
 
@@ -69,7 +70,20 @@ class ErrorModelsSpec extends FunSpec with Matchers {
 
     val errorCode = Services.buildEnum("error_code", "error_codes")
     linter.validate(baseService.copy(enums = Seq(errorCode))) should be(Nil)
+  }
 
+  it("ignores where specified") {
+    val service = buildService(Nil).copy(
+      models = Seq(
+        Services.buildModel("my_error").copy(
+          attributes = Seq(Attribute("linter", Json.obj("ignore" -> Json.arr("error_models"))))
+        )
+      )
+    )
+    linter.validate(service) should be(Nil)
+
+    val service2 = buildService(Nil)
+    linter.validate(service2) shouldNot be(Nil)
   }
   
 }


### PR DESCRIPTION
This is for https://github.com/flowcommerce/api/pull/778 to pass. We ignore the ErrorModels because it wants a valid enum for `code`, but since `code` is imported it doesn't recognize it. Ideally we would resolve imports in api-build