### PR TITLE
Add linter to prevent 'sort' param for any op with a 'q' param

### DIFF
--- a/src/main/scala/io/flow/lint/Lint.scala
+++ b/src/main/scala/io/flow/lint/Lint.scala
@@ -26,6 +26,7 @@ object Lint {
     linters.ExpandableUnionsAreConsistent,
     linters.Get,
     linters.GetByIdIsExpandable,
+    linters.GetQuerySort,
     linters.LowerCasePaths,
     linters.MinimumMaximum,
     linters.ModelsWithOrganizationField,

--- a/src/main/scala/io/flow/lint/linters/GetQuerySort.scala
+++ b/src/main/scala/io/flow/lint/linters/GetQuerySort.scala
@@ -1,0 +1,33 @@
+package io.flow.lint.linters
+
+import io.apibuilder.spec.v0.models.{Operation, Parameter, ParameterLocation, Resource, Service}
+import io.flow.lint.Linter
+
+/**
+  * Enforces that all GET methods that have a 'q' param do NOT have
+  * a 'sort' param. We do this because q indicates search; with algolia
+  * there is no way to do a dynamic sort, and pre-indexing all the sort
+  * resulted in too large a working set - and thus we cannot offer
+  * sorting.
+  */
+case object GetQuerySort extends Linter with Helpers {
+
+  override def validate(service: Service): Seq[String] = {
+    nonHealthcheckResources(service).map(validateResource(service, _)).flatten
+  }
+
+  private[this] def validateResource(service: Service, resource: Resource): Seq[String] = {
+    resource.operations.
+      filter( op => hasQueryParameter(op, "q")).
+      filter( op => hasQueryParameter(op, "sort")).
+      map { op =>
+        error(resource, op, s"Parameter[sort] is not supported for operations that contain a 'q' parameter")
+      }
+  }
+
+  private[this] def hasQueryParameter(operation: Operation, name: String): Boolean = {
+    operation.parameters.exists { p =>
+      p.location == ParameterLocation.Query && p.name == name
+    }
+  }
+}

--- a/src/test/scala/io/flow/lint/GetQuerySortSpec.scala
+++ b/src/test/scala/io/flow/lint/GetQuerySortSpec.scala
@@ -1,0 +1,80 @@
+package io.flow.lint
+
+import io.apibuilder.spec.v0.models._
+import org.scalatest.{FunSpec, Matchers}
+
+class GetQuerySortSpec extends FunSpec with Matchers {
+
+  private[this] val linter = linters.GetQuerySort
+
+  private[this] val model = Services.buildSimpleModel(
+    "organization",
+    fields = Seq("id", "name")
+  )
+
+  private[this] val qParameter = Parameter(
+    name = "q",
+    `type` = "string",
+    location = ParameterLocation.Query,
+    required = false
+  )
+
+  private[this] val sortParameter = Parameter(
+    name = "sort",
+    `type` = "string",
+    location = ParameterLocation.Query,
+    required = false
+  )
+
+  def buildResourceWithSearch(params: Seq[Parameter]) = {
+    Services.Base.copy(
+      resources = Seq(
+        Resource(
+          `type` = "organization",
+          plural = "organizations",
+          operations = Seq(
+            Operation(
+              method = Method.Get,
+              path = "/organizations",
+              parameters = params,
+              responses = Seq(
+                Services.buildResponse(`type` = "[organization]")
+              )
+            )
+          )
+        )
+      )
+    )
+  }
+
+  it("has no errors if 'q' specified without 'sort'") {
+    linter.validate(
+      buildResourceWithSearch(
+        Seq(qParameter)
+      )
+    ) should be(
+      Nil
+    )
+  }
+
+  it("validates sort is allowed if no 'q' parameter") {
+    linter.validate(
+      buildResourceWithSearch(
+        Seq(sortParameter)
+      )
+    ) should be(
+      Nil
+    )
+  }
+
+  it("validates sort is NOT allowed if 'q' parameter") {
+    linter.validate(
+      buildResourceWithSearch(
+        Seq(qParameter, sortParameter)
+      )
+    ) should be(
+      Seq("Resource organizations GET /organizations: Parameter[sort] is not supported for operations that contain a 'q' parameter")
+    )
+  }
+
+}


### PR DESCRIPTION
Enforces that all GET methods that have a 'q' param do NOT have
  a 'sort' param. We do this because q indicates search; with algolia
  there is no way to do a dynamic sort, and pre-indexing all the sort
  options resulted in too large a working set - and thus we cannot
  offer sorting mixed with queries