### PR TITLE
Validate union type errors

### DIFF
--- a/src/main/scala/io/flow/lint/linters/Helpers.scala
+++ b/src/main/scala/io/flow/lint/linters/Helpers.scala
@@ -32,6 +32,10 @@ trait Helpers {
     }
   }
 
+  def isError(typeName: String): Boolean = {
+    typeName.endsWith("_error")
+  }
+
   /**
     * Returns the model for this resource. Right now only will resolve
     * if the model is defined directly in the service (i.e. not
@@ -44,7 +48,7 @@ trait Helpers {
   def model(service: Service, name: String): Option[Model] = {
     service.models.find(_.name == name)
   }
-  
+
   /**
     * Returns the union type for the successful response type for this
     * operation. Right now only will resolve if the model is defined
@@ -55,7 +59,16 @@ trait Helpers {
       service.unions.find(_.name == t)
     }
   }
-  
+
+  /**
+    * Returns the union types for the provided model, if any.
+    */
+  def unions(service: Service, model: Model): Seq[Union] = {
+    service.unions.filter { u =>
+      u.types.map(_.`type`).contains(model.name)
+    }
+  }
+
   /**
     * Returns the model for the successful response type for this
     * operation. Right now only will resolve if the model is defined
@@ -115,6 +128,10 @@ trait Helpers {
 
   def error(union: Union, error: String): String = {
     s"Union ${union.name}: $error"
+  }
+
+  def error(union: Union, typ: UnionType, error: String): String = {
+    s"Union ${union.name} type ${typ.`type`}: $error"
   }
 
   def error(model: Model, error: String): String = {

--- a/src/main/scala/io/flow/lint/linters/UnionTypesHaveCommonDiscriminator.scala
+++ b/src/main/scala/io/flow/lint/linters/UnionTypesHaveCommonDiscriminator.scala
@@ -9,20 +9,27 @@ import io.apibuilder.spec.v0.models.{Service, Union}
   */
 case object UnionTypesHaveCommonDiscriminator extends Linter with Helpers {
 
-  private[this] val StandardName = "discriminator"
-
   override def validate(service: Service): Seq[String] = {
     service.unions.
       filter(op => !ignored(op.attributes, "discriminator")).
-      flatMap(validateUnion(_))
+      flatMap(validateUnion)
   }
 
   def validateUnion(union: Union): Seq[String] = {
+    val expected = expectedDiscriminator(union.name)
+
     union.discriminator match {
-      case None => Seq(error(union, s"Must have a discriminator with value '$StandardName'"))
-      case Some(StandardName) => Nil
-      case Some(actual) => Seq(error(union, s"Discriminator must have value '$StandardName' and not '$actual'"))
+      case None => Seq(error(union, s"Must have a discriminator with value '$expected'"))
+      case Some(actual) if actual == expected => Nil
+      case Some(actual) => Seq(error(union, s"Discriminator must have value '$expected' and not '$actual'"))
     }
   }
 
+  private[this] def expectedDiscriminator(typeName: String): String = {
+    if (isError(typeName)) {
+      "code"
+    } else {
+      "discriminator"
+    }
+  }
 }

--- a/src/test/scala/io/flow/lint/ErrorModelsSpec.scala
+++ b/src/test/scala/io/flow/lint/ErrorModelsSpec.scala
@@ -7,8 +7,8 @@ class ErrorModelsSpec extends FunSpec with Matchers {
 
   private[this] val linter = linters.ErrorModels
 
-  val code = Services.buildField("code")
-  val messages = Services.buildField("messages", "[string]", minimum = Some(1))
+  private[this] val code = Services.buildField("code")
+  private[this] val messages = Services.buildField("messages", "[string]", minimum = Some(1))
 
   def buildService(
     fields: Seq[Field]

--- a/src/test/scala/io/flow/lint/ErrorUnionModelsSpec.scala
+++ b/src/test/scala/io/flow/lint/ErrorUnionModelsSpec.scala
@@ -1,0 +1,94 @@
+package io.flow.lint
+
+import io.apibuilder.spec.v0.models._
+import org.scalatest.{FunSpec, Matchers}
+
+class ErrorUnionModelsSpec extends FunSpec with Matchers {
+
+  private[this] val linter = linters.ErrorModels
+
+  private[this] val messages = Services.buildField("messages", "[string]", minimum = Some(1))
+
+  def buildService(
+    fields: Seq[Field],
+    modelName: String = "no_inventory_reservation_error",
+    unionName: String = "reservation_error",
+    discriminator: Option[String] = Some("code")
+  ): Service = {
+    Services.Base.copy(
+      unions = Seq(
+        Services.buildUnion(
+          name = unionName,
+          discriminator = discriminator,
+          types = Seq(
+            UnionType(`type` = modelName)
+          )
+        )
+      ),
+      models = Seq(
+        Services.buildModel(
+          name = modelName,
+          fields = fields
+        )
+      )
+    )
+  }
+
+  it("Must have a discriminator named 'code' and associated models must have a field in position 0 named 'messages' of type '[string]'") {
+    linter.validate(buildService(Seq(messages))) should be(Nil)
+
+    val itemNumbers = Services.buildField("item_numbers", "[string]")
+    linter.validate(buildService(Seq(messages, itemNumbers))) should be(Nil)
+
+    linter.validate(buildService(Seq(itemNumbers, messages))) should be(
+      Seq(
+        "Model no_inventory_reservation_error: second field must be 'messages'"
+      )
+    )
+
+    linter.validate(buildService(Nil)) should be(Seq(
+      "Model no_inventory_reservation_error: requires a field named 'messages'"
+    ))
+  }
+
+  it("messages must have a minimum >= 1") {
+    linter.validate(buildService(Seq(messages.copy(minimum=None)))) should be(Seq(
+      "Model no_inventory_reservation_error Field[messages]: missing minimum"
+    ))
+    linter.validate(buildService(Seq(messages.copy(minimum=Some(0))))) should be(Seq(
+      "Model no_inventory_reservation_error Field[messages]: minimum must be >= 1"
+    ))
+  }
+
+  it("error union types MUST contain only models") {
+    linter.validate(
+      Services.Base.copy(
+        unions = Seq(
+          Services.buildUnion(
+            name = "reservation_error",
+            discriminator = Some("code"),
+            types = Seq(
+              UnionType(`type` = "string")
+            )
+          )
+        )
+      )
+    ) should be(
+      Seq("Union reservation_error type string: Type must refer to a model to be part of an 'error' union type")
+    )
+  }
+
+  it("All error union types must end in _error as well") {
+    linter.validate(buildService(Seq(messages), modelName = "foo")) should be(Seq(
+      "Union reservation_error type foo: Model name must end with '_error'"
+    ))
+  }
+
+  it("error model that belongs to a non error union type should still get validated") {
+    linter.validate(buildService(Seq(messages), unionName = "other")) should be(
+      Seq(
+        "Model no_inventory_reservation_error: requires a field named 'code'"
+      )
+    )
+  }
+}

--- a/src/test/scala/io/flow/lint/UnionTypesHaveCommonDiscriminatorSpec.scala
+++ b/src/test/scala/io/flow/lint/UnionTypesHaveCommonDiscriminatorSpec.scala
@@ -41,4 +41,20 @@ class UnionTypesHaveCommonDiscriminatorSpec extends FunSpec with Matchers {
     linter.validate(buildService("expandable_user", Some("discriminator"))) should be (Nil)
   }
 
+  it("union types that end in _error must have a discriminator named 'code'") {
+    linter.validate(buildService("user_error", None)) should be (
+      Seq("Union user_error: Must have a discriminator with value 'code'")
+    )
+  }
+
+  it("union types that end in _error with invalid discriminator") {
+    linter.validate(buildService("user_error", Some("foo"))) should be (
+      Seq("Union user_error: Discriminator must have value 'code' and not 'foo'")
+    )
+  }
+
+  it("union types that end in _error with valid discriminator") {
+    linter.validate(buildService("user_error", Some("code"))) should be (Nil)
+  }
+
 }


### PR DESCRIPTION
- Solve for:
```
  - Model no_inventory_reservation_error: requires a field named 'code'
  - Union reservation_error: Discriminator must have value 'discriminator' and not 'code'
```