### PR TITLE
Fix bug in sort of operations

### DIFF
--- a/src/main/scala/io/flow/oneapi/OperationSort.scala
+++ b/src/main/scala/io/flow/oneapi/OperationSort.scala
@@ -1,0 +1,50 @@
+package io.flow.oneapi
+
+import io.apibuilder.spec.v0.models.{Method, Operation}
+
+object OperationSort {
+
+  /**
+    * Sort the operations in order so that any statically declared references
+    * sort before equivalent dynamically declared references. For example:
+    *
+    *  - /:organization/experiences/:key
+    *  - /:organization/experiences/items
+    *
+    * We need the /items path to support before /:key else it is never
+    * resolved
+    */
+  def key(op: Operation): String = {
+    (
+      op.path.split("/").filter(_.nonEmpty).map { p =>
+        if (p.startsWith(":")) {
+          // Path component has a dynamic element in it - push to end
+          s"z_$p"
+        } else {
+          s"a_$p"
+        }
+      } ++ Seq(methodSortOrder(op.method).toString)
+    ).mkString(":")
+  }
+
+  /**
+    * Returns a numeric index by which we can sort methods. This
+    * allows us to present, for example, all operations with a GET
+    * Method first.
+    */
+  private[this] def methodSortOrder(method: Method): Int = {
+    method match {
+      case Method.Get => 1
+      case Method.Post => 2
+      case Method.Put => 3
+      case Method.Patch => 4
+      case Method.Delete => 5
+      case Method.Connect => 6
+      case Method.Head => 7
+      case Method.Options => 8
+      case Method.Trace => 9
+      case Method.UNDEFINED(_) => 10
+    }
+  }
+  
+}

--- a/src/main/scala/io/flow/oneapi/OperationSort.scala
+++ b/src/main/scala/io/flow/oneapi/OperationSort.scala
@@ -11,8 +11,7 @@ object OperationSort {
     *  - /:organization/experiences/:key
     *  - /:organization/experiences/items
     *
-    * We need the /items path to support before /:key else it is never
-    * resolved
+    * We need the /items path to sort before /:key else it never resolves
     */
   def key(op: Operation): String = {
     (

--- a/src/test/scala/io/flow/lint/Services.scala
+++ b/src/test/scala/io/flow/lint/Services.scala
@@ -176,7 +176,7 @@ object Services {
     path: String,
     parameters: Seq[Parameter] = Nil,
     responseCode: Int = 200,
-    responseType: String,
+    responseType: String = "string",
     attributes: Seq[Attribute] = Nil
   ): Operation = {
     Operation(

--- a/src/test/scala/io/flow/oneapi/OperationSortSpec.scala
+++ b/src/test/scala/io/flow/oneapi/OperationSortSpec.scala
@@ -1,0 +1,63 @@
+package io.flow.oneapi
+
+import io.apibuilder.spec.v0.models.Method
+import io.flow.lint.Services
+import org.scalatest.{FunSpec, Matchers}
+
+class OperationSortSpec extends FunSpec with Matchers {
+
+  it("static paths") {
+    Seq(
+      Services.buildSimpleOperation(
+        path = "/organizations/id"
+      ),
+      Services.buildSimpleOperation(
+        path = "/organizations"
+      )
+    ).sortBy(OperationSort.key).map(_.path) should equal(
+      Seq("/organizations", "/organizations/id")
+    )
+  }
+
+  it("GET before POST") {
+    Seq(
+      Services.buildSimpleOperation(
+        method = Method.Post,
+        path = "/organizations"
+      ),
+      Services.buildSimpleOperation(
+        method = Method.Get,
+        path = "/organizations"
+      )
+    ).sortBy(OperationSort.key).map(_.method) should equal(
+      Seq(Method.Get, Method.Post)
+    )
+  }
+
+  it("simple dynamic paths") {
+    Seq(
+      Services.buildSimpleOperation(
+        path = "/:organization/experiences/:key"
+      ),
+      Services.buildSimpleOperation(
+        path = "/:organization/experiences"
+      )
+    ).sortBy(OperationSort.key).map(_.path) should equal(
+      Seq("/:organization/experiences", "/:organization/experiences/:key")
+    )
+  }
+
+  it("complex dynamic paths") {
+    Seq(
+      Services.buildSimpleOperation(
+        path = "/:organization/experiences/:key"
+      ),
+      Services.buildSimpleOperation(
+        path = "/:organization/experiences/items"
+      )
+    ).sortBy(OperationSort.key).map(_.path) should equal(
+      Seq("/:organization/experiences/items", "/:organization/experiences/:key")
+    )
+  }
+
+}


### PR DESCRIPTION
Sort the operations in order so that any statically declared references
  sort before equivalent dynamically declared references. For example:

    - /:organization/experiences/:key
    - /:organization/experiences/items

  We need the /items path to sort before /:key else it never resolves
