### PR TITLE
Convert namespaces to flow API

### DIFF
--- a/src/main/scala/io/flow/oneapi/Datatype.scala
+++ b/src/main/scala/io/flow/oneapi/Datatype.scala
@@ -1,5 +1,7 @@
 package io.flow.oneapi
 
+import io.flow.build.BuildType
+
 import scala.util.matching.Regex
 
 sealed trait TextDatatype
@@ -33,7 +35,7 @@ object TextDatatype {
   * Parses a text datatype, removing specific namespaces as those
   * names are expected to be local
   */
-case class TextDatatypeParser() {
+case class TextDatatypeParser(buildType: BuildType) {
   import TextDatatype._
 
   def parse(value: String): Seq[TextDatatype] = {
@@ -65,7 +67,11 @@ case class TextDatatypeParser() {
 
   def maybeStripNamespace(value: String): String = {
     if (TextDatatype.isNamespaceInFlowApiProject(value)) {
-      value.split("\\.").last
+      val name = value.split("\\.").last
+      buildType match {
+        case BuildType.Api => name
+        case _ => s"io.flow.v0.$name"
+      }
     } else {
       value
     }

--- a/src/main/scala/io/flow/oneapi/OneApi.scala
+++ b/src/main/scala/io/flow/oneapi/OneApi.scala
@@ -99,7 +99,7 @@ case class OneApi(
       }
     }
 
-    val parser = TextDatatypeParser()
+    val parser = TextDatatypeParser(buildType)
     val localTypes: Seq[String] = services.flatMap { s =>
       s.enums.map(e => withNamespace(s, e.name)) ++ s.models.map(m => withNamespace(s, m.name)) ++ s.unions.map(u => withNamespace(s, u.name))
     }
@@ -405,37 +405,9 @@ case class OneApi(
   def localizeType(parser: TextDatatypeParser, name: String): String = {
     buildType match {
       case BuildType.Api => parser.toString(parser.parse(name))
-      case BuildType.ApiEvent => toApiImport(parser, name)
-      case BuildType.ApiInternal | BuildType.ApiInternalEvent | BuildType.ApiPartner | BuildType.ApiMisc | BuildType.ApiMiscEvent => name
-    }
-  }
-
-  private[this] val ApiServiceRx = """^io\.flow\..+\.v0\.(\w+).(\w+)$""".r
-  private[this] val ApiServiceArrayRx = """^\[io\.flow\..+\.v0\.(\w+).(\w+)\]$""".r
-  private[this] val ApiServiceMapRx = """^map\[io\.flow\..+\.v0\.(\w+).(\w+)\]$""".r
-
-  /**
-    * Rewrite imports in api-event to allow imports from api
-    */
-  def toApiImport(parser: TextDatatypeParser, name: String): String = {
-    val simpleName = parser.toString(parser.parse(name))
-    if (simpleName == name) {
-      name
-    } else {
-      name match {
-        case ApiServiceRx(_, _) | ApiServiceArrayRx(_, _) | ApiServiceMapRx(_, _) => {
-          // TODO: figure out how to import. we have a circular
-          // dependency as api project is built after
-          // api-event. Probably need to move the generate event
-          // union/enum into api-event
-          //
-          // s"io.flow.api.v0.$apidocType.$typeName"
-          name
-        }
-        case _ => {
-          sys.error(s"Failed to map import to API project for type[$name]")
-        }
-      }
+      case BuildType.ApiEvent => name
+      case BuildType.ApiInternal => parser.toString(parser.parse(name))
+      case BuildType.ApiInternalEvent | BuildType.ApiPartner | BuildType.ApiMisc | BuildType.ApiMiscEvent => name
     }
   }
 


### PR DESCRIPTION
- api-internal models that reference types in the 'api' project need to have
    their types rewritten. Ex:

    old: order	io.flow.experience.v0.models.order_put_form
    new: order  io.flow.api.order_put_form