### PR TITLE
Introduce 'host' attribute to allow a service to declare it's host

### DIFF
--- a/src/main/scala/io/flow/proxy/ApiBuildAttributes.scala
+++ b/src/main/scala/io/flow/proxy/ApiBuildAttributes.scala
@@ -1,0 +1,30 @@
+package io.flow.proxy
+
+import io.apibuilder.spec.v0.models.Service
+import play.api.libs.json.{JsString, JsValue}
+
+/**
+  * Helper to parse the values defined for
+  * the attribute named 'api-build'
+  */
+case class ApiBuildAttributes(services: Seq[Service]) {
+
+  def host(serviceName: String): Option[String] = {
+    get(serviceName, "host").map(_.asInstanceOf[JsString].value)
+  }
+
+  private[this] def get(serviceName: String, attributeName: String): Option[JsValue] = {
+    services.find(_.name.toLowerCase == serviceName.toLowerCase) match {
+      case None => None
+      case Some(svc) => apiBuildAttributeValue(svc, attributeName)
+    }
+  }
+
+  private[this] def apiBuildAttributeValue(service: Service, name: String): Option[JsValue] = {
+    service.attributes.find(_.name == "api-build") match {
+      case None => None
+      case Some(attr) => attr.value.value.get(name)
+    }
+  }
+  
+}

--- a/src/main/scala/io/flow/proxy/Controller.scala
+++ b/src/main/scala/io/flow/proxy/Controller.scala
@@ -14,10 +14,10 @@ case class Controller() extends io.flow.build.Controller {
   private[this] val ExcludeWhiteList = Seq("common", "healthcheck", "usage", "gift-card")
 
   private[this] val HostingMap = Map(
-    "optin"->"content",
+    "optin"-> "content",
     "consumer-invoice" -> "order-messenger",
     "shopify-session" -> "session",
-    "permission"        -> "organization",
+    "permission" -> "organization",
     "checkout" -> "experience",
     "checkout-configuration" -> "organization"
   )
@@ -75,19 +75,11 @@ case class Controller() extends io.flow.build.Controller {
       filterNot { s => ExcludeWhiteList.exists(ew => s.name.startsWith(ew)) }
 
     def serviceHost(name: String): String = {
-      buildType match {
-        case BuildType.Api => {
-          val specName = name.toLowerCase
-          HostingMap.getOrElse(specName, specName)
-        }
-        case BuildType.ApiEvent => name.toLowerCase
-        case BuildType.ApiInternal => {
-          val specName = Text.stripSuffix(name.toLowerCase, "-internal")
-          HostingMap.getOrElse(specName, specName)
-        }
-        case BuildType.ApiInternalEvent => Text.stripSuffix(name.toLowerCase, "-internal-event")
-        case BuildType.ApiMisc | BuildType.ApiMiscEvent => sys.error("Proxy does not support api-misc")
-        case BuildType.ApiPartner => name.toLowerCase
+      val formattedName = Text.stripSuffix(
+        Text.stripSuffix(name.toLowerCase, "-internal-event"), "-internal"
+      )
+      ApiBuildAttributes(allServices).host(formattedName).getOrElse {
+        HostingMap.getOrElse(formattedName, formattedName)
       }
     }
 

--- a/src/main/scala/io/flow/proxy/ServiceHostResolver.scala
+++ b/src/main/scala/io/flow/proxy/ServiceHostResolver.scala
@@ -14,6 +14,7 @@ case class ServiceHostResolver(services: Seq[Service]) {
     "checkout" -> "experience",
     "checkout-configuration" -> "organization"
   )
+
   def host(serviceName: String): String = {
     apiBuildAttributes.host(serviceName).getOrElse {
       val formattedName = Text.stripSuffix(

--- a/src/main/scala/io/flow/proxy/ServiceHostResolver.scala
+++ b/src/main/scala/io/flow/proxy/ServiceHostResolver.scala
@@ -6,6 +6,7 @@ case class ServiceHostResolver(services: Seq[Service]) {
 
   private[this] val apiBuildAttributes = ApiBuildAttributes(services)
 
+  // TODO: Remove hosting map by adding attributes into these services
   private[this] val HostingMap = Map(
     "optin"-> "content",
     "consumer-invoice" -> "order-messenger",

--- a/src/main/scala/io/flow/proxy/ServiceHostResolver.scala
+++ b/src/main/scala/io/flow/proxy/ServiceHostResolver.scala
@@ -1,0 +1,27 @@
+package io.flow.proxy
+
+import io.apibuilder.spec.v0.models.Service
+
+case class ServiceHostResolver(services: Seq[Service]) {
+
+  private[this] val apiBuildAttributes = ApiBuildAttributes(services)
+
+  private[this] val HostingMap = Map(
+    "optin"-> "content",
+    "consumer-invoice" -> "order-messenger",
+    "shopify-session" -> "session",
+    "permission" -> "organization",
+    "checkout" -> "experience",
+    "checkout-configuration" -> "organization"
+  )
+  def host(serviceName: String): String = {
+    apiBuildAttributes.host(serviceName).getOrElse {
+      val formattedName = Text.stripSuffix(
+        Text.stripSuffix(serviceName.toLowerCase, "-internal-event"), "-internal"
+      )
+      apiBuildAttributes.host(formattedName).getOrElse {
+        HostingMap.getOrElse(formattedName, formattedName)
+      }
+    }
+  }
+}

--- a/src/test/scala/io/flow/helpers/ServiceHostHelpers.scala
+++ b/src/test/scala/io/flow/helpers/ServiceHostHelpers.scala
@@ -1,0 +1,20 @@
+package io.flow.helpers
+
+import io.apibuilder.spec.v0.models.{Attribute, Service}
+import io.flow.lint.Services
+import play.api.libs.json.Json
+
+trait ServiceHostHelpers {
+
+  def serviceWithHost(name: String, host: Option[String] = None): Service = {
+    Services.Base.copy(name = name,
+      attributes = host.map { h =>
+        Attribute(
+          name = "api-build",
+          value = Json.obj("host" -> h)
+        )
+      }.toSeq
+    )
+  }
+
+}

--- a/src/test/scala/io/flow/proxy/ApiBuildAttributesSpec.scala
+++ b/src/test/scala/io/flow/proxy/ApiBuildAttributesSpec.scala
@@ -1,33 +1,21 @@
 package io.flow.proxy
 
-import io.apibuilder.spec.v0.models.{Attribute, Service}
-import io.flow.lint.Services
+import io.flow.helpers.ServiceHostHelpers
 import org.scalatest.{FunSpec, Matchers}
-import play.api.libs.json.Json
 
-class ApiBuildAttributesSpec extends FunSpec with Matchers {
-
-  private[this] def svc(name: String, host: Option[String] = None): Service = {
-    Services.Base.copy(
-      name = name,
-      attributes = host.map { h =>
-        Attribute(
-          name = "api-build",
-          value = Json.obj("host" -> h)
-        )
-      }.toSeq
-    )
-  }
+class ApiBuildAttributesSpec extends FunSpec with Matchers
+  with ServiceHostHelpers
+{
 
   it("host with no attribute") {
     ApiBuildAttributes(
-      Seq(svc("user"))
+      Seq(serviceWithHost("user"))
     ).host("user") should be(None)
   }
 
   it("host with attribute") {
     ApiBuildAttributes(
-      Seq(svc("user"), svc("foo", Some("bar")))
+      Seq(serviceWithHost("user"), serviceWithHost("foo", Some("bar")))
     ).host("foo") should be(Some("bar"))
   }
 }

--- a/src/test/scala/io/flow/proxy/ApiBuildAttributesSpec.scala
+++ b/src/test/scala/io/flow/proxy/ApiBuildAttributesSpec.scala
@@ -1,0 +1,33 @@
+package io.flow.proxy
+
+import io.apibuilder.spec.v0.models.{Attribute, Service}
+import io.flow.lint.Services
+import org.scalatest.{FunSpec, Matchers}
+import play.api.libs.json.Json
+
+class ApiBuildAttributesSpec extends FunSpec with Matchers {
+
+  private[this] def svc(name: String, host: Option[String] = None): Service = {
+    Services.Base.copy(
+      name = name,
+      attributes = host.map { h =>
+        Attribute(
+          name = "api-build",
+          value = Json.obj("host" -> h)
+        )
+      }.toSeq
+    )
+  }
+
+  it("host with no attribute") {
+    ApiBuildAttributes(
+      Seq(svc("user"))
+    ).host("user") should be(None)
+  }
+
+  it("host with attribute") {
+    ApiBuildAttributes(
+      Seq(svc("user"), svc("foo", Some("bar")))
+    ).host("foo") should be(Some("bar"))
+  }
+}

--- a/src/test/scala/io/flow/proxy/ServiceHostResolverSpec.scala
+++ b/src/test/scala/io/flow/proxy/ServiceHostResolverSpec.scala
@@ -1,0 +1,56 @@
+package io.flow.proxy
+
+import io.flow.helpers.ServiceHostHelpers
+import org.scalatest.{FunSpec, Matchers}
+
+class ServiceHostResolverSpec extends FunSpec with Matchers
+  with ServiceHostHelpers
+{
+
+  it("host defaults to name of service") {
+    val resolver = ServiceHostResolver(
+      Seq(
+        serviceWithHost("foo")
+      )
+    )
+    resolver.host("foo") should be("foo")
+  }
+
+  it("host strips internal suffixes") {
+    val resolver = ServiceHostResolver(
+      Seq(
+        serviceWithHost("user"),
+        serviceWithHost("user-internal"),
+        serviceWithHost("user-internal-event")
+      )
+    )
+    resolver.host("user") should be("user")
+    resolver.host("user-internal") should be("user")
+    resolver.host("user-internal-event") should be("user")
+  }
+
+  it("respects attribute when specified") {
+    val resolver = ServiceHostResolver(
+      Seq(
+        serviceWithHost("user", Some("foo")),
+        serviceWithHost("user-internal", Some("bar")),
+        serviceWithHost("user-internal-event", Some("baz"))
+      )
+    )
+    resolver.host("user") should be("foo")
+    resolver.host("user-internal") should be("bar")
+    resolver.host("user-internal-event") should be("baz")
+  }
+
+  it("respects attribute 'host' on parent") {
+    val resolver = ServiceHostResolver(
+      Seq(
+        serviceWithHost("user", Some("foo")),
+        serviceWithHost("user-internal")
+      )
+    )
+    resolver.host("user") should be("foo")
+    resolver.host("user-internal") should be("foo")
+  }
+
+}


### PR DESCRIPTION
  - Will allow removal of HostingMap hack in Controller
  - Example: https://github.com/flowcommerce/api/pull/1520
```
{
  "name": "catalog-exclusion",
  "attributes": [
    {
      "name": "api-build",
      "value": {
        "host": "catalog"
      }
    }
  ]
}
```

This means that the service defined by 'catalog-exclusion' should be served
by the same host as the service named 'catalog' - ie. catalog-exclusion
will be served from catalog.flow.io