### PR TITLE
Port to scopt for arg parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
     - $HOME/.sbt
     - $HOME/.cache/coursier
 script: 
-  - sbt ++$TRAVIS_SCALA_VERSION clean compile test doc one-jar
+  - sbt ++$TRAVIS_SCALA_VERSION clean compile test doc assembly
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
     - $HOME/.sbt
     - $HOME/.cache/coursier
 script: 
-  - sbt ++$TRAVIS_SCALA_VERSION clean compile test doc
+  - sbt ++$TRAVIS_SCALA_VERSION clean compile test doc one-jar
 branches:
   only:
     - master

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ lazy val root = project
       "com.typesafe.play" %% "play-json" % "2.7.4",
       "com.ning" % "async-http-client" % "1.9.40",
       "org.scalatest" %% "scalatest" % "3.0.8" % Test,
-      "com.github.scopt" %% "scopt" % "3.7.0",
+      "com.github.scopt" %% "scopt" % "3.7.1",
       compilerPlugin("com.github.ghik" %% "silencer-plugin" % "1.4.2"),
       "com.github.ghik" %% "silencer-lib" % "1.4.2" % Provided
     )

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,7 @@ lazy val root = project
       "com.typesafe.play" %% "play-json" % "2.7.4",
       "com.ning" % "async-http-client" % "1.9.40",
       "org.scalatest" %% "scalatest" % "3.0.8" % Test,
+      "com.github.scopt" %% "scopt" % "3.7.0",
       compilerPlugin("com.github.ghik" %% "silencer-plugin" % "1.4.2"),
       "com.github.ghik" %% "silencer-lib" % "1.4.2" % Provided
     )

--- a/src/main/scala/io/flow/build/Config.scala
+++ b/src/main/scala/io/flow/build/Config.scala
@@ -1,0 +1,7 @@
+package io.flow.build
+
+case class Config(
+  buildType: BuildType = BuildType.Api,
+  buildCommand: String = "all",
+  apis: Seq[String] = Seq()
+)

--- a/src/main/scala/io/flow/build/Main.scala
+++ b/src/main/scala/io/flow/build/Main.scala
@@ -29,28 +29,28 @@ object Main extends App {
     }
     case Right(profile) => {
       implicit val buildTypeRead: scopt.Read[BuildType] =
-        scopt.Read.reads(s => BuildType.fromString(s).get)
+        scopt.Read.reads(s => BuildType.fromString(s).getOrElse(sys.error(s"Unknown BuildType '$s'")))
 
       val parser = new scopt.OptionParser[Config]("api-build") {
         override def showUsageOnError = true
 
         arg[BuildType]("<build type>")
           .action((bt, c) => c.copy(buildType = bt))
-          .text(BuildType.all.map(_.toString).mkString(", "))
+          .text("One of: " + BuildType.all.map(_.toString).mkString(", "))
           .required()
 
         arg[String]("<build command>")
           .action((cmd, c) => c.copy(buildCommand = cmd))
-          .text(controllers(BuildType.Api).map(_.command).mkString("all, ", ", ", ""))
+          .text("One of: " + controllers(BuildType.Api).map(_.command).mkString("all, ", ", ", ""))
           .required()
 
-        arg[String]("<flow/api1>...")
+        arg[String]("<flow/experience>...")
           .text("API specs from APIBuilder")
           .unbounded()
           .optional()
           .validate(api => Application.parse(api) match {
             case Some(_) => success
-            case None => failure(s"Could not parse application[${api}]")
+            case None => failure(s"Could not parse application[$api]")
           })
 
         help("help")

--- a/src/main/scala/io/flow/build/Main.scala
+++ b/src/main/scala/io/flow/build/Main.scala
@@ -46,6 +46,7 @@ object Main extends App {
 
         arg[String]("<flow/experience>...")
           .text("API specs from APIBuilder")
+          .action((api, c) => c.copy(apis = c.apis :+ api))
           .unbounded()
           .optional()
           .validate(api => Application.parse(api) match {
@@ -104,7 +105,6 @@ object Main extends App {
   }
 
   private[this] def run(buildType: BuildType, downloader: Downloader, controllers: Seq[Controller], services: Seq[Service]): Unit = {
-
     val errors = scala.collection.mutable.Map[String, Seq[String]]()
     if (globalErrors.nonEmpty) {
       errors += ("config" -> globalErrors)

--- a/src/main/scala/io/flow/build/Main.scala
+++ b/src/main/scala/io/flow/build/Main.scala
@@ -27,59 +27,78 @@ object Main extends App {
       println(s"** Error loading apibuilder config: $error")
       System.exit(1)
     }
-
     case Right(profile) => {
-      args.toList match {
-        case Nil => {
-          println(s"** ERROR: Specify type[${BuildType.all.mkString(", ")}] and command[lint|oneapi|all]")
-        }
+      implicit val buildTypeRead: scopt.Read[BuildType] =
+        scopt.Read.reads(s => BuildType.fromString(s).get)
 
-        case _ :: Nil => {
-          println(s"** ERROR: Specify type[${BuildType.all.mkString(", ")}] and command[lint|oneapi|all]")
-        }
+      val parser = new scopt.OptionParser[Config]("api-build") {
+        override def showUsageOnError = true
 
-        case typ :: command :: rest => {
-          BuildType.fromString(typ) match {
-            case None => {
-              println(s"** ERROR: Invalid buildType[$typ]. Must be one of: " + BuildType.all.mkString(", "))
+        arg[BuildType]("<build type>")
+          .action((bt, c) => c.copy(buildType = bt))
+          .text(BuildType.all.map(_.toString).mkString(", "))
+          .required()
+
+        arg[String]("<build command>")
+          .action((cmd, c) => c.copy(buildCommand = cmd))
+          .text(controllers(BuildType.Api).map(_.command).mkString("all, ", ", ", ""))
+          .required()
+
+        arg[String]("<flow/api1>...")
+          .text("API specs from APIBuilder")
+          .unbounded()
+          .optional()
+          .validate(api => Application.parse(api) match {
+            case Some(_) => success
+            case None => failure(s"Could not parse application[${api}]")
+          })
+
+        help("help")
+
+        checkConfig(c => {
+          val selected = if (c.buildCommand == "all") {
+            controllers(c.buildType)
+          } else {
+            controllers(c.buildType).filter(_.command == c.buildCommand)
+          }
+          selected.toList match {
+            case Nil => {
+              failure(s"Invalid command[${c.buildCommand}] for build type[${c.buildType}]. " +
+                s"Must be one of: all, " + controllers(c.buildType).map(_.command).mkString(", "))
             }
+            case _ => {
+              success
+            }
+          }
+        })
+      }
 
-            case Some(buildType) => {
-              val selected = if (command == "all") { controllers(buildType) } else { controllers(buildType).filter(_.command == command) }
-              selected.toList match {
-                case Nil => {
-                  println(s"** ERROR: Invalid command[$command]. Must be one of: all, " + controllers(buildType).map(_.command).mkString(", "))
-                }
+      parser.parse(args, Config()) match {
+        case Some(config) =>
+          val selected = if (config.buildCommand == "all") {
+            controllers(config.buildType)
+          } else {
+            controllers(config.buildType).filter(_.command == config.buildCommand)
+          }
 
-                case _ => {
-                  Downloader.withClient(profile) { dl =>
-                    val services = rest.flatMap { name =>
-                      Application.parse(name) match {
-                        case None => {
-                          globalErrors += s"Could not parse application[$name]"
-                          None
-                        }
-
-                        case Some(app) => {
-                          dl.service(app) match {
-                            case Left(error) => {
-                              globalErrors += s"Failed to download app[${app.label}]: $error"
-                              None
-                            }
-                            case Right(service) => {
-                              Some(service)
-                            }
-                          }
-                        }
-                      }
-                    }
-                    run(buildType, dl, selected, services)
+          Downloader.withClient(profile) { dl =>
+            val services = config.apis.flatMap { name =>
+              Application.parse(name).flatMap { app =>
+                dl.service(app) match {
+                  case Left(error) => {
+                    globalErrors += s"Failed to download app[${app.label}]: $error"
+                    None
+                  }
+                  case Right(service) => {
+                    Some(service)
                   }
                 }
               }
             }
+            run(config.buildType, dl, selected, services)
           }
-        }
+        case None =>
+          // error message already printed
       }
     }
   }

--- a/src/main/scala/io/flow/proxy/Controller.scala
+++ b/src/main/scala/io/flow/proxy/Controller.scala
@@ -3,7 +3,6 @@ package io.flow.proxy
 import io.apibuilder.spec.v0.models.Service
 import io.flow.build.{Application, BuildType, Downloader}
 import io.flow.registry.v0.{Client => RegistryClient}
-import Text._
 import play.api.libs.json.Json
 
 case class Controller() extends io.flow.build.Controller {

--- a/src/main/scala/io/flow/proxy/Controller.scala
+++ b/src/main/scala/io/flow/proxy/Controller.scala
@@ -2,6 +2,7 @@ package io.flow.proxy
 
 import io.apibuilder.spec.v0.models.Service
 import io.flow.build.{Application, BuildType, Downloader}
+import io.flow.proxy.Text._
 import io.flow.registry.v0.{Client => RegistryClient}
 import play.api.libs.json.Json
 


### PR DESCRIPTION
[scopt](https://github.com/scopt/scopt) is a scala library for argument parsing. I wanted this for https://app.clubhouse.io/flow/story/23460/api-build-should-not-download-from-apibuilder-io-when-run-in-travis.

I tested this with `./script/build` in `api` repo and `diff`ed it with the existing `api-build.jar` in s3. The only differences were whitespace (are there missing changes in s3 from `master`? not sure why else it would have any diff at all).

This also gives us some nice help text:
```shell
$ java -jar api-build.jar --help
Usage: api-build [options] <build type> <build command> [<flow/experience>...]

  <build type>          One of: api, api-event, api-internal, api-internal-event, api-misc, api-misc-event, api-partner
  <build command>       One of: all, lint, stream, oneapi, proxy
  <flow/experience>...  API specs from APIBuilder
  --help
```

and some nicer validation:
```shell
$ java -jar api-build.jar api-waffle syrup
Error: Argument <build type> failed when given 'api-waffle'. Unknown BuildType 'api-waffle'
Error: Invalid command[syrup] for build type[api]. Must be one of: all, lint, stream, oneapi, proxy
Usage: api-build [options] <build type> <build command> [<flow/experience>...]

  <build type>          One of: api, api-event, api-internal, api-internal-event, api-misc, api-misc-event, api-partner
  <build command>       One of: all, lint, stream, oneapi, proxy
  <flow/experience>...  API specs from APIBuilder
  --help
```