### PR TITLE
Remove linter hint to skip discriminator - union types must have a discriminator

### DIFF
--- a/src/main/scala/io/flow/lint/linters/UnionTypesHaveCommonDiscriminator.scala
+++ b/src/main/scala/io/flow/lint/linters/UnionTypesHaveCommonDiscriminator.scala
@@ -10,9 +10,7 @@ import io.apibuilder.spec.v0.models.{Service, Union}
 case object UnionTypesHaveCommonDiscriminator extends Linter with Helpers {
 
   override def validate(service: Service): Seq[String] = {
-    service.unions.
-      filter(op => !ignored(op.attributes, "discriminator")).
-      flatMap(validateUnion)
+    service.unions.flatMap(validateUnion)
   }
 
   def validateUnion(union: Union): Seq[String] = {


### PR DESCRIPTION
- otherwise json serialization is odd and unstable