### PR TITLE
Upgrade libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,10 +24,10 @@ lazy val root = project
     scalacOptions += "-P:silencer:pathFilters=src/main/scala/io/flow/generated/.*",
     libraryDependencies ++= Seq(
       "io.flow" %% "lib-util" % "0.1.53",
-      "io.apibuilder" %% "apibuilder-validation" % "0.4.21",
-      "com.typesafe.play" %% "play-json" % "2.9.0",
+      "io.apibuilder" %% "apibuilder-validation" % "0.4.28",
+      "com.typesafe.play" %% "play-json" % "2.9.1",
       "com.ning" % "async-http-client" % "1.9.40",
-      "org.scalatest" %% "scalatest" % "3.2.1" % Test,
+      "org.scalatest" %% "scalatest" % "3.2.2" % Test,
       "com.github.scopt" %% "scopt" % "3.7.1",
       compilerPlugin("com.github.ghik" %% "silencer-plugin" % "1.7.0" cross CrossVersion.full),
       "com.github.ghik" %% "silencer-lib" % "1.7.0" % Provided cross CrossVersion.full


### PR DESCRIPTION
- com.typesafe.play
  - play-json (2.9.0 => 2.9.1)
- io.apibuilder
  - apibuilder-validation (0.4.21 => 0.4.28)
- org.scalatest
  - scalatest (3.2.1 => 3.2.2)