### PR TITLE
Allow type as a discriminator name

### DIFF
--- a/src/test/scala/io/flow/lint/UnionTypesHaveCommonDiscriminatorSpec.scala
+++ b/src/test/scala/io/flow/lint/UnionTypesHaveCommonDiscriminatorSpec.scala
@@ -28,13 +28,13 @@ class UnionTypesHaveCommonDiscriminatorSpec extends AnyFunSpec with Matchers {
 
   it("with no discriminator") {
     linter.validate(buildService("expandable_user", None)) should be (
-      Seq("Union expandable_user: Must have a discriminator with value 'discriminator'")
+      Seq("Union expandable_user: Must have a discriminator with value one of ('discriminator', 'type')")
     )
   }
 
   it("with invalid discriminator") {
     linter.validate(buildService("expandable_user", Some("foo"))) should be (
-      Seq("Union expandable_user: Discriminator must have value 'discriminator' and not 'foo'")
+      Seq("Union expandable_user: Discriminator must have value one of ('discriminator', 'type') and not 'foo'")
     )
   }
 
@@ -48,13 +48,13 @@ class UnionTypesHaveCommonDiscriminatorSpec extends AnyFunSpec with Matchers {
 
   it("union types that end in _error must have a discriminator named 'code'") {
     linter.validate(buildService("user_error", None)) should be (
-      Seq("Union user_error: Must have a discriminator with value 'code'")
+      Seq("Union user_error: Must have a discriminator with value one of ('code')")
     )
   }
 
   it("union types that end in _error with invalid discriminator") {
     linter.validate(buildService("user_error", Some("foo"))) should be (
-      Seq("Union user_error: Discriminator must have value 'code' and not 'foo'")
+      Seq("Union user_error: Discriminator must have value one of ('code') and not 'foo'")
     )
   }
 

--- a/src/test/scala/io/flow/lint/UnionTypesHaveCommonDiscriminatorSpec.scala
+++ b/src/test/scala/io/flow/lint/UnionTypesHaveCommonDiscriminatorSpec.scala
@@ -42,6 +42,10 @@ class UnionTypesHaveCommonDiscriminatorSpec extends AnyFunSpec with Matchers {
     linter.validate(buildService("expandable_user", Some("discriminator"))) should be (Nil)
   }
 
+  it("with valid discriminator - type") {
+    linter.validate(buildService("expandable_user", Some("type"))) should be (Nil)
+  }
+
   it("with valid discriminator for localized_price hack") {
     linter.validate(buildService("localized_price", Some("key"))) should be (Nil)
   }


### PR DESCRIPTION
This PR allows to use `type` (in addition to `discriminator`) as a discriminator name.