### PR TITLE
Stream: Prewarm the cache of downloaded services (speed improvement)

### DIFF
--- a/src/main/scala/io/flow/build/Application.scala
+++ b/src/main/scala/io/flow/build/Application.scala
@@ -8,7 +8,7 @@ case class Application(
   val isLatest: Boolean = version == Application.Latest
 
   val applicationVersionLabel: String = if (isLatest) {
-    application
+    s"$application:latest"
   } else {
     s"$application:$version"
   }

--- a/src/main/scala/io/flow/build/DownloadCache.scala
+++ b/src/main/scala/io/flow/build/DownloadCache.scala
@@ -17,7 +17,6 @@ case class DownloadCache(downloader: Downloader)(
 
   @tailrec
   final def downloadAllServicesAndImports(services: Seq[Service], index: Int = 0): Seq[Service] = {
-    assert(index < 4)
     val all = services ++ mustDownloadServices(
       services.flatMap(_.imports).map(toApplication)
     )

--- a/src/main/scala/io/flow/build/DownloadCache.scala
+++ b/src/main/scala/io/flow/build/DownloadCache.scala
@@ -1,7 +1,8 @@
 package io.flow.build
 
-import io.apibuilder.spec.v0.models.Service
+import io.apibuilder.spec.v0.models.{Import, Service}
 
+import scala.annotation.tailrec
 import scala.collection.concurrent.TrieMap
 
 case class DownloadCache(downloader: Downloader)(
@@ -10,12 +11,36 @@ case class DownloadCache(downloader: Downloader)(
 
   private[this] val cache = TrieMap[Application, Service]()
 
+  private[this] def cacheKey(a: Application) = Application.latest(a.organization, a.application)
+  private[this] def isDefinedAt(application: Application): Boolean = cache.isDefinedAt(cacheKey(application))
+  private[this] def toApplication(imp: Import): Application = Application.latest(imp.organization.key, imp.application.key)
+
+  @tailrec
+  final def downloadAllServicesAndImports(services: Seq[Service], index: Int = 0): Seq[Service] = {
+    assert(index < 4)
+    val all = services ++ mustDownloadServices(
+      services.flatMap(_.imports).map(toApplication)
+    )
+    val missing = all.flatMap(_.imports).map(toApplication).filterNot(isDefinedAt)
+    if (missing.isEmpty) {
+      all
+    } else {
+      downloadAllServicesAndImports(all, index + 1)
+    }
+  }
+
+  def mustDownloadServices(applications: Seq[Application]): Seq[Service] = {
+    downloadServices(applications) match {
+      case Left(errors) => sys.error(s"Failed to download services: ${errors.mkString(", ")}")
+      case Right(services) => services
+    }
+  }
+
   def downloadServices(
     applications: Seq[Application]
   ): Either[Seq[String], Seq[Service]] = {
-    def cacheKey(a: Application) = Application.latest(a.organization, a.application)
 
-    val (cached, remaining) = applications.partition { a => cache.isDefinedAt(cacheKey(a)) }
+    val (cached, remaining) = applications.partition { a => isDefinedAt(cacheKey(a)) }
 
     downloader.downloadServices(remaining.distinct).map { rest =>
       rest.foreach { s =>

--- a/src/main/scala/io/flow/oneapi/OneApi.scala
+++ b/src/main/scala/io/flow/oneapi/OneApi.scala
@@ -31,16 +31,13 @@ case class OneApi(
 
   private[this] val namespace = s"${buildType.namespace}.v" + majorVersion(canonical.service.version)
 
-  private[this] val importedServices: List[ApiBuilderService] = downloadCache.downloadServices(
+  private[this] val importedServices: List[ApiBuilderService] = downloadCache.mustDownloadServices(
     originalServices.flatMap(_.imports).map { imp =>
       io.flow.build.Application.latest(imp.organization.key, imp.application.key)
     }.distinct.filterNot { a =>
       originalServices.exists { s => s.organization.key == a.organization && s.application.key == a.application }
     }
-  ) match {
-    case Left(errors) => sys.error(s"Failed to download imports: ${errors.mkString(", ")}")
-    case Right(services) => services.map(ApiBuilderService(_)).toList
-  }
+  ).map(ApiBuilderService(_)).toList
 
   private[this] val services: List[ApiBuilderService] = originalServices.map(ApiBuilderService(_)).toList
   private[this] val multiService: MultiService = MultiServiceImpl(services)


### PR DESCRIPTION
This change adds a utility to the DownloadCache to recursively fetch all services and imports. This then enables the stream controller to make a total of 3 API calls to API Builder to fetch all services instead of fetching each service one by one. The net result is a 2-3x speed improvement (on my laptop goes from ~13 seconds to ~4 seconds):

```
Downloading API Builder Service Spec for flow: adyen:latest billing-internal:latest billing:latest catalog-exclusion:latest catalog-internal:latest catalog-return:latest catalog:latest checkout-configuration:latest common:latest content-internal:latest currency-internal:latest currency:latest customer:latest duty-internal:latest experience-internal:latest experience:latest experiment-internal:latest feature:latest fraud-internal:latest ftp:latest fulfillment:latest harmonization-engine-internal:latest harmonization-internal:latest issuer:latest item-classification-api:latest item-dimension-estimate:latest label-internal:latest marketing-gateway:latest optin-internal:latest order-management-event:latest order-management:latest payment-internal:latest price:latest ratecard-internal:latest ratecard:latest reference:latest shopify-internal:latest tax-internal:latest tracking-internal:latest tracking:latest
Downloading API Builder Service Spec for flow: bitpay:latest checkout-common:latest crypto:latest error:latest field-validation:latest flexe:latest fraud:latest harmonization:latest inventory:latest invoice:latest item:latest label:latest merchant-of-record:latest order-price:latest organization:latest payment-gateway:latest payment:latest paypal:latest permission:latest price-internal:latest query-builder:latest return:latest session:latest shopify-external:latest shopify:latest stripe:latest svb:latest ups-license:latest ups-registration:latest
Downloading API Builder Service Spec for flow: apple-pay:latest google-pay:latest session-context:latest
```

Test command:
```
run api-internal-event stream flow/tracking-internal-event flow/payment-internal-event flow/ratecard-internal-event flow/published-internal-event flow/customer-internal-event flow/user-internal-event flow/checkout-configuration-event flow/experiment-internal-event flow/order-management-internal-event flow/label-internal-event flow/experience-internal-event flow/catalog-internal-event flow/paypal-internal-event flow/marketing-gateway-internal-event flow/feature-event flow/ftp-event flow/item-dimension-estimate-event flow/harmonization-internal-event flow/shopify-internal-event flow/tax-internal-event flow/content-internal-event flow/currency-internal-event flow/localized-item-internal-event flow/pricing-indicator-internal-event flow/issuer-event flow/hybris-internal-event flow/optin-internal-event flow/import-internal-event flow/duty-internal-event flow/billing-event flow/svb-internal-event flow/fraud-internal-event flow/export-internal-event flow/fulfillment-internal-pregenerated-event flow/adyen-internal-event flow/stripe-internal-event flow/billing-internal-event
```

Before:
```
[success] Total time: 13 s, completed Oct 2, 2021, 4:13:04 PM
```

After the change:
```
[success] Total time: 4 s, completed Oct 2, 2021, 4:13:42 PM
```