### PR TITLE
FDN-3275 Add support for different domain and protocol

### DIFF
--- a/src/main/scala/io/flow/build/BuildConfig.scala
+++ b/src/main/scala/io/flow/build/BuildConfig.scala
@@ -6,5 +6,7 @@ package io.flow.build
   *   Used by the proxy controller when constructing the value of each host in the servers list.
   * @param domain
   *   Used by the proxy controller when constructing the value of each host in the servers list.
+  * @param output
+  *   Where controllers write files created.
   */
-case class BuildConfig(protocol: String, domain: String)
+case class BuildConfig(protocol: String, domain: String, output: java.nio.file.Path)

--- a/src/main/scala/io/flow/build/BuildConfig.scala
+++ b/src/main/scala/io/flow/build/BuildConfig.scala
@@ -1,0 +1,10 @@
+package io.flow.build
+
+/** Additional configuration passed to the run method of each Controller.
+  *
+  * @param protocol
+  *   Used by the proxy controller when constructing the value of each host in the servers list.
+  * @param domain
+  *   Used by the proxy controller when constructing the value of each host in the servers list.
+  */
+case class BuildConfig(protocol: String, domain: String)

--- a/src/main/scala/io/flow/build/Config.scala
+++ b/src/main/scala/io/flow/build/Config.scala
@@ -6,4 +6,5 @@ case class Config(
   domain: String = "api.flow.io",
   buildCommand: String = "all",
   apis: Seq[String] = Seq(),
+  output: java.nio.file.Path = java.nio.file.Paths.get("/tmp"),
 )

--- a/src/main/scala/io/flow/build/Config.scala
+++ b/src/main/scala/io/flow/build/Config.scala
@@ -2,6 +2,8 @@ package io.flow.build
 
 case class Config(
   buildType: BuildType = BuildType.Api,
+  protocol: String = "https",
+  domain: String = "api.flow.io",
   buildCommand: String = "all",
   apis: Seq[String] = Seq(),
 )

--- a/src/main/scala/io/flow/build/Controller.scala
+++ b/src/main/scala/io/flow/build/Controller.scala
@@ -31,6 +31,7 @@ trait Controller {
     */
   def run(
     buildType: BuildType,
+    buildConfig: BuildConfig,
     downloadCache: DownloadCache,
     services: Seq[Service],
   )(implicit

--- a/src/main/scala/io/flow/lint/Controller.scala
+++ b/src/main/scala/io/flow/lint/Controller.scala
@@ -1,7 +1,7 @@
 package io.flow.lint
 
 import io.apibuilder.spec.v0.models.Service
-import io.flow.build.{BuildType, DownloadCache}
+import io.flow.build.{BuildConfig, BuildType, DownloadCache}
 
 case class Controller() extends io.flow.build.Controller {
 
@@ -10,6 +10,7 @@ case class Controller() extends io.flow.build.Controller {
 
   def run(
     buildType: BuildType,
+    buildConfig: BuildConfig,
     downloadCache: DownloadCache,
     services: Seq[Service],
   )(implicit

--- a/src/main/scala/io/flow/oneapi/Controller.scala
+++ b/src/main/scala/io/flow/oneapi/Controller.scala
@@ -46,7 +46,7 @@ case class Controller() extends io.flow.build.Controller {
         import io.apibuilder.spec.v0.models.json._
         import play.api.libs.json._
 
-        val path = s"/tmp/flow-$buildType.json"
+        val path = buildConfig.output.resolve(s"flow-$buildType.json").toFile
         new java.io.PrintWriter(path) {
           write(Json.prettyPrint(Json.toJson(service)))
           close()

--- a/src/main/scala/io/flow/oneapi/Controller.scala
+++ b/src/main/scala/io/flow/oneapi/Controller.scala
@@ -2,7 +2,7 @@ package io.flow.oneapi
 
 import cats.data.Validated.{Invalid, Valid}
 import io.apibuilder.spec.v0.models.Service
-import io.flow.build.{Application, BuildType, DownloadCache}
+import io.flow.build.{Application, BuildConfig, BuildType, DownloadCache}
 
 case class Controller() extends io.flow.build.Controller {
 
@@ -11,6 +11,7 @@ case class Controller() extends io.flow.build.Controller {
 
   def run(
     buildType: BuildType,
+    buildConfig: BuildConfig,
     downloadCache: DownloadCache,
     services: Seq[Service],
   )(implicit

--- a/src/main/scala/io/flow/proxy/Controller.scala
+++ b/src/main/scala/io/flow/proxy/Controller.scala
@@ -1,7 +1,7 @@
 package io.flow.proxy
 
 import io.apibuilder.spec.v0.models.Service
-import io.flow.build.{Application, BuildType, DownloadCache}
+import io.flow.build.{Application, BuildConfig, BuildType, DownloadCache}
 import io.flow.registry.v0.{Client => RegistryClient}
 import play.api.libs.json.Json
 
@@ -59,6 +59,7 @@ case class Controller() extends io.flow.build.Controller {
 
   def run(
     buildType: BuildType,
+    buildConfig: BuildConfig,
     downloadCache: DownloadCache,
     allServices: Seq[Service],
   )(implicit
@@ -83,7 +84,7 @@ case class Controller() extends io.flow.build.Controller {
     val registryClient = new RegistryClient()
     try {
       buildProxyFile(buildType, services, version, "production") { service =>
-        s"https://${serviceHostResolver.host(service.name)}.api.flow.io"
+        s"${buildConfig.protocol}://${serviceHostResolver.host(service.name)}.${buildConfig.domain}"
       }
 
       val cache = RegistryApplicationCache(registryClient)

--- a/src/main/scala/io/flow/stream/Controller.scala
+++ b/src/main/scala/io/flow/stream/Controller.scala
@@ -2,7 +2,7 @@ package io.flow.stream
 
 import io.apibuilder.spec.v0.models.{Field, Model, Service, UnionType}
 import io.apibuilder.validation.{ApiBuilderService, ApiBuilderType, MultiService}
-import io.flow.build.{Application, BuildType, DownloadCache}
+import io.flow.build.{Application, BuildConfig, BuildType, DownloadCache}
 import io.flow.util.{FlowEnvironment, StreamNames, VersionParser}
 
 import scala.annotation.tailrec
@@ -19,7 +19,12 @@ case class Controller() extends io.flow.build.Controller {
   override val name = "Stream"
   override val command = "stream"
 
-  override def run(buildType: BuildType, downloadCache: DownloadCache, services: Seq[Service])(implicit
+  override def run(
+    buildType: BuildType,
+    buildConfig: BuildConfig,
+    downloadCache: DownloadCache,
+    services: Seq[Service],
+  )(implicit
     ec: ExecutionContext,
   ): Unit = {
 


### PR DESCRIPTION
Backward compatible change in that neither of the 2 new parameters (--http-only, --domain) are required.

Allows for example
```
sbt "run api proxy --http-only --domain production flow/calculator"
```

to produce a different value for the host

```
 more /tmp/api-proxy.production.config
version: 0.19.6

servers:
  - name: calculator
    host: http://calculator.production

operations:
  - method: POST
    path: /:organization/levy/quotes
    server: calculator

```

**Edit:**  also added --output parameter to allow writing of output to a folder other than /tmp (still the default)