### PR TITLE
[TAC-2980] Add ge_catalog_item_event to list of verbose events

### DIFF
--- a/src/main/scala/io/flow/lint/linters/EventStructure.scala
+++ b/src/main/scala/io/flow/lint/linters/EventStructure.scala
@@ -172,6 +172,7 @@ case object EventStructure extends Linter with EventHelpers {
 
   private val FilteredVerboseEventModels = Set(
     "catalog_item_event",
+    "ge_catalog_item_event",
     "product_event",
   )
 


### PR DESCRIPTION
JIRA [TAC-2980](https://flowio.atlassian.net/browse/TAC-2980)

We are adding a new event called `ge_catalog_item_event` which has the same structure and general behaviour as the existing `catalog_item_event` to ingest enterprise item events.

To maintain the same structure, we need the new event to be excluded from the linting rules.