### PR TITLE
FDN-4099 Add support for explicit configuration of production servers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,6 +53,9 @@ lazy val root = project
       "org.typelevel" %% "cats-effect" % "2.3.3",
       "org.scalatest" %% "scalatest" % "3.2.19" % Test,
       "com.github.scopt" %% "scopt" % "4.1.0",
+      "io.circe" %% "circe-generic" % "0.14.9",
+      "io.circe" %% "circe-parser" % "0.14.9",
+      "io.circe" %% "circe-yaml" % "0.16.1",
     ),
   )
 

--- a/src/main/scala/io/flow/build/BuildConfig.scala
+++ b/src/main/scala/io/flow/build/BuildConfig.scala
@@ -9,4 +9,9 @@ package io.flow.build
   * @param output
   *   Where controllers write files created.
   */
-case class BuildConfig(protocol: String, domain: String, output: java.nio.file.Path)
+case class BuildConfig(
+  protocol: String,
+  domain: String,
+  productionServerConfigs: Seq[ServerConfig],
+  output: java.nio.file.Path,
+)

--- a/src/main/scala/io/flow/build/Config.scala
+++ b/src/main/scala/io/flow/build/Config.scala
@@ -1,10 +1,104 @@
 package io.flow.build
 
+import io.flow.{lint, oneapi, proxy, stream}
+import scopt.OptionParser
+
+import java.nio.file.{Files, Path}
+
 case class Config(
   buildType: BuildType = BuildType.Api,
   protocol: String = "https",
   domain: String = "api.flow.io",
+  productionConfig: Option[java.nio.file.Path] = None,
   buildCommand: String = "all",
   apis: Seq[String] = Seq(),
   output: java.nio.file.Path = java.nio.file.Paths.get("/tmp"),
 )
+
+object Config {
+  def parseArgs(args: Array[String]): Option[Config] = makeParser().parse(args, Config())
+
+  private implicit val BuildTypeRead: scopt.Read[BuildType] =
+    scopt.Read.reads(s => BuildType.fromString(s).getOrElse(sys.error(s"Unknown BuildType '$s'")))
+
+  private def makeParser(): OptionParser[Config] = new scopt.OptionParser[Config]("api-build") {
+    override def showUsageOnError: Option[Boolean] = Some(true)
+
+    arg[BuildType]("<build type>")
+      .action((bt, c) => c.copy(buildType = bt))
+      .text("One of: " + BuildType.all.map(_.toString).mkString(", "))
+      .required()
+
+    arg[String]("<build command>")
+      .action((cmd, c) => c.copy(buildCommand = cmd))
+      .text("One of: " + controllers(BuildType.Api).map(_.command).mkString("all, ", ", ", ""))
+      .required()
+
+    opt[Unit]("http-only")
+      .text("If specified, results in http being used as the protocol in host names (default is 'https')")
+      .action((_, c) => c.copy(protocol = "http"))
+
+    opt[String]('d', "domain")
+      .text("Domain to use when constructing the service subdomain (default is 'api.flow.io')")
+      .action((d, c) => c.copy(domain = d))
+
+    opt[Path]("production-config")
+      .text("Optional yaml file to provide host configuration for servers (production only)")
+      .action((path, c) => c.copy(productionConfig = Some(path)))
+
+    opt[Path]('o', "output")
+      .text("Where to write output files (default is '/tmp')")
+      .validate { path =>
+        if (!Files.exists(path)) failure(s"Path does not exist: $path")
+        else if (!Files.isDirectory(path)) failure(s"Path is not a directory: $path")
+        else success
+      }
+      .action((p, c) => c.copy(output = p))
+
+    arg[String]("<flow/experience>...")
+      .text("API specs from APIBuilder")
+      .action((api, c) => c.copy(apis = c.apis :+ api))
+      .unbounded()
+      .optional()
+      .validate(api =>
+        Application.parse(api) match {
+          case Some(_) => success
+          case None => failure(s"Could not parse application[$api]")
+        },
+      )
+
+    help("help")
+
+    checkConfig(c => {
+      val selected = if (c.buildCommand == "all") {
+        controllers(c.buildType)
+      } else {
+        controllers(c.buildType).filter(_.command == c.buildCommand)
+      }
+      selected.toList match {
+        case Nil => {
+          failure(
+            s"Invalid command[${c.buildCommand}] for build type[${c.buildType}]. " +
+              s"Must be one of: all, " + controllers(c.buildType).map(_.command).mkString(", "),
+          )
+        }
+        case _ => {
+          success
+        }
+      }
+    })
+  }
+
+  private def controllers(buildType: BuildType): Seq[Controller] = {
+    val all = scala.collection.mutable.ListBuffer[Controller]()
+    all.append(lint.Controller())
+    all.append(stream.Controller())
+    if (buildType.oneApi) {
+      all.append(oneapi.Controller())
+    }
+    if (buildType.proxy) {
+      all.append(proxy.Controller())
+    }
+    all.toSeq
+  }
+}

--- a/src/main/scala/io/flow/build/Config.scala
+++ b/src/main/scala/io/flow/build/Config.scala
@@ -45,8 +45,8 @@ object Config {
     opt[Path]("production-config")
       .text("Optional yaml file to provide host configuration for servers (production only)")
       .validate { path =>
-        if (!Files.exists(path)) failure(s"Production config file does not exist: $path")
-        else if (!Files.isRegularFile(path)) failure(s"Production config path is not a file: $path")
+        if (!Files.exists(path)) failure(s"Production config file does not exist: '$path'")
+        else if (!Files.isRegularFile(path)) failure(s"Production config path is not a file: '$path'")
         else success
       }
       .action((path, c) => c.copy(productionConfig = Some(path)))

--- a/src/main/scala/io/flow/build/Config.scala
+++ b/src/main/scala/io/flow/build/Config.scala
@@ -9,7 +9,7 @@ case class Config(
   buildType: BuildType = BuildType.Api,
   protocol: String = "https",
   domain: String = "api.flow.io",
-  productionConfig: Option[java.nio.file.Path] = None,
+  overrideConfig: Option[java.nio.file.Path] = None,
   buildCommand: String = "all",
   apis: Seq[String] = Seq(),
   output: java.nio.file.Path = java.nio.file.Paths.get("/tmp"),
@@ -42,14 +42,14 @@ object Config {
       .text("Domain to use when constructing the service subdomain (default is 'api.flow.io')")
       .action((d, c) => c.copy(domain = d))
 
-    opt[Path]("production-config")
-      .text("Optional yaml file to provide host configuration for servers (production only)")
+    opt[Path]("override-config")
+      .text("Optional yaml file to override default configuration for servers (production only)")
       .validate { path =>
-        if (!Files.exists(path)) failure(s"Production config file does not exist: '$path'")
-        else if (!Files.isRegularFile(path)) failure(s"Production config path is not a file: '$path'")
+        if (!Files.exists(path)) failure(s"Override config file does not exist: '$path'")
+        else if (!Files.isRegularFile(path)) failure(s"Override config path is not a file: '$path'")
         else success
       }
-      .action((path, c) => c.copy(productionConfig = Some(path)))
+      .action((path, c) => c.copy(overrideConfig = Some(path)))
     opt[Path]('o', "output")
       .text("Where to write output files (default is '/tmp')")
       .validate { path =>

--- a/src/main/scala/io/flow/build/Config.scala
+++ b/src/main/scala/io/flow/build/Config.scala
@@ -44,8 +44,12 @@ object Config {
 
     opt[Path]("production-config")
       .text("Optional yaml file to provide host configuration for servers (production only)")
+      .validate { path =>
+        if (!Files.exists(path)) failure(s"Production config file does not exist: $path")
+        else if (!Files.isRegularFile(path)) failure(s"Production config path is not a file: $path")
+        else success
+      }
       .action((path, c) => c.copy(productionConfig = Some(path)))
-
     opt[Path]('o', "output")
       .text("Where to write output files (default is '/tmp')")
       .validate { path =>

--- a/src/main/scala/io/flow/build/Config.scala
+++ b/src/main/scala/io/flow/build/Config.scala
@@ -9,7 +9,7 @@ case class Config(
   buildType: BuildType = BuildType.Api,
   protocol: String = "https",
   domain: String = "api.flow.io",
-  overrideConfig: Option[java.nio.file.Path] = None,
+  productionConfigOverride: Option[java.nio.file.Path] = None,
   buildCommand: String = "all",
   apis: Seq[String] = Seq(),
   output: java.nio.file.Path = java.nio.file.Paths.get("/tmp"),
@@ -42,14 +42,14 @@ object Config {
       .text("Domain to use when constructing the service subdomain (default is 'api.flow.io')")
       .action((d, c) => c.copy(domain = d))
 
-    opt[Path]("override-config")
+    opt[Path]("production-override-config")
       .text("Optional yaml file to override default configuration for servers (production only)")
       .validate { path =>
         if (!Files.exists(path)) failure(s"Override config file does not exist: '$path'")
         else if (!Files.isRegularFile(path)) failure(s"Override config path is not a file: '$path'")
         else success
       }
-      .action((path, c) => c.copy(overrideConfig = Some(path)))
+      .action((path, c) => c.copy(productionConfigOverride = Some(path)))
     opt[Path]('o', "output")
       .text("Where to write output files (default is '/tmp')")
       .validate { path =>

--- a/src/main/scala/io/flow/build/Config.scala
+++ b/src/main/scala/io/flow/build/Config.scala
@@ -42,7 +42,7 @@ object Config {
       .text("Domain to use when constructing the service subdomain (default is 'api.flow.io')")
       .action((d, c) => c.copy(domain = d))
 
-    opt[Path]("production-override-config")
+    opt[Path]("production-config-override")
       .text("Optional yaml file to override default configuration for servers (production only)")
       .validate { path =>
         if (!Files.exists(path)) failure(s"Override config file does not exist: '$path'")

--- a/src/main/scala/io/flow/build/Main.scala
+++ b/src/main/scala/io/flow/build/Main.scala
@@ -39,7 +39,7 @@ object Main extends App {
           val allApplications: Seq[Application] = config.apis.flatMap { name =>
             Application.parse(name)
           }
-          val serverConfigs: Seq[ServerConfig] = config.productionConfig
+          val serverConfigs: Seq[ServerConfig] = config.overrideConfig
             .map { path =>
               ServerConfig.parseFile(path) match {
                 case Left(error) => sys.error(s"Failed to parse $path: '$error'")

--- a/src/main/scala/io/flow/build/Main.scala
+++ b/src/main/scala/io/flow/build/Main.scala
@@ -3,8 +3,6 @@ package io.flow.build
 import io.apibuilder.spec.v0.models.Service
 import io.flow.{lint, oneapi, proxy, stream}
 
-import java.nio.file.{Files, Path}
-
 object Main extends App {
 
   import scala.concurrent.ExecutionContext.Implicits.global
@@ -29,75 +27,8 @@ object Main extends App {
       println(s"** Error loading apibuilder config: $error")
       System.exit(1)
     }
-    case Right(profile) => {
-      implicit val buildTypeRead: scopt.Read[BuildType] =
-        scopt.Read.reads(s => BuildType.fromString(s).getOrElse(sys.error(s"Unknown BuildType '$s'")))
-
-      val parser = new scopt.OptionParser[Config]("api-build") {
-        override def showUsageOnError = Some(true)
-
-        arg[BuildType]("<build type>")
-          .action((bt, c) => c.copy(buildType = bt))
-          .text("One of: " + BuildType.all.map(_.toString).mkString(", "))
-          .required()
-
-        arg[String]("<build command>")
-          .action((cmd, c) => c.copy(buildCommand = cmd))
-          .text("One of: " + controllers(BuildType.Api).map(_.command).mkString("all, ", ", ", ""))
-          .required()
-
-        opt[Unit]("http-only")
-          .text("If specified, results in http being used as the protocol in host names (default is 'https')")
-          .action((_, c) => c.copy(protocol = "http"))
-
-        opt[String]('d', "domain")
-          .text("Domain to use when constructing the service subdomain (default is 'api.flow.io')")
-          .action((d, c) => c.copy(domain = d))
-
-        opt[Path]('o', "output")
-          .text("Where to write output files (default is '/tmp')")
-          .validate { path =>
-            if (!Files.exists(path)) failure(s"Path does not exist: $path")
-            else if (!Files.isDirectory(path)) failure(s"Path is not a directory: $path")
-            else success
-          }
-          .action((p, c) => c.copy(output = p))
-
-        arg[String]("<flow/experience>...")
-          .text("API specs from APIBuilder")
-          .action((api, c) => c.copy(apis = c.apis :+ api))
-          .unbounded()
-          .optional()
-          .validate(api =>
-            Application.parse(api) match {
-              case Some(_) => success
-              case None => failure(s"Could not parse application[$api]")
-            },
-          )
-
-        help("help")
-
-        checkConfig(c => {
-          val selected = if (c.buildCommand == "all") {
-            controllers(c.buildType)
-          } else {
-            controllers(c.buildType).filter(_.command == c.buildCommand)
-          }
-          selected.toList match {
-            case Nil => {
-              failure(
-                s"Invalid command[${c.buildCommand}] for build type[${c.buildType}]. " +
-                  s"Must be one of: all, " + controllers(c.buildType).map(_.command).mkString(", "),
-              )
-            }
-            case _ => {
-              success
-            }
-          }
-        })
-      }
-
-      parser.parse(args, Config()) match {
+    case Right(profile) =>
+      Config.parseArgs(args) match {
         case Some(config) =>
           val selected = if (config.buildCommand == "all") {
             controllers(config.buildType)
@@ -108,20 +39,34 @@ object Main extends App {
           val allApplications: Seq[Application] = config.apis.flatMap { name =>
             Application.parse(name)
           }
-          val buildConfig = BuildConfig(protocol = config.protocol, domain = config.domain, output = config.output)
+          val serverConfigs: Seq[ServerConfig] = config.productionConfig
+            .map { path =>
+              ServerConfig.parseFile(path) match {
+                case Left(error) => sys.error(s"Failed to parse $path: '$error'")
+                case Right(serverConfigs) => serverConfigs
+              }
+            }
+            .getOrElse(Nil)
+
+          val buildConfig = BuildConfig(
+            protocol = config.protocol,
+            domain = config.domain,
+            productionServerConfigs = serverConfigs,
+            output = config.output,
+          )
           val dl = DownloadCache(Downloader(profile))
           dl.downloadServices(allApplications) match {
-            case Left(errors) => {
+            case Left(errors) =>
               println(s"Errors downloading services:")
               errors.foreach { e => println(s" - $e") }
               System.exit(errors.length)
-            }
-            case Right(services) => run(config.buildType, buildConfig, dl, selected, services)
+
+            case Right(services) =>
+              run(config.buildType, buildConfig, dl, selected, services)
           }
         case None =>
         // error message already printed
       }
-    }
   }
 
   private[this] def run(

--- a/src/main/scala/io/flow/build/Main.scala
+++ b/src/main/scala/io/flow/build/Main.scala
@@ -39,7 +39,7 @@ object Main extends App {
           val allApplications: Seq[Application] = config.apis.flatMap { name =>
             Application.parse(name)
           }
-          val serverConfigs: Seq[ServerConfig] = config.overrideConfig
+          val serverConfigs: Seq[ServerConfig] = config.productionConfigOverride
             .map { path =>
               ServerConfig.parseFile(path) match {
                 case Left(error) => sys.error(s"Failed to parse $path: '$error'")

--- a/src/main/scala/io/flow/build/ServerConfig.scala
+++ b/src/main/scala/io/flow/build/ServerConfig.scala
@@ -5,14 +5,17 @@ import io.circe.generic.auto._
 import io.circe.yaml
 
 import scala.io.Source
-import scala.util.Using
+import scala.util.{Failure, Success, Using}
 
 case class ServerConfig(name: String, host: String)
 
 object ServerConfig {
   def parseFile(path: java.nio.file.Path): Either[String, Seq[ServerConfig]] =
-    Using.resource(Source.fromFile(path.toUri)) { source =>
+    Using(Source.fromFile(path.toUri)) { source =>
       parseYaml(source.mkString)
+    } match {
+      case Failure(ex) => Left(ex.getMessage)
+      case Success(result) => result
     }
 
   def parseYaml(contents: String): Either[String, Seq[ServerConfig]] = {

--- a/src/main/scala/io/flow/build/ServerConfig.scala
+++ b/src/main/scala/io/flow/build/ServerConfig.scala
@@ -1,0 +1,26 @@
+package io.flow.build
+
+import cats.implicits._
+import io.circe.generic.auto._
+import io.circe.yaml
+
+import scala.io.Source
+import scala.util.Using
+
+case class ServerConfig(name: String, host: String)
+
+object ServerConfig {
+  def parseFile(path: java.nio.file.Path): Either[String, Seq[ServerConfig]] =
+    Using.resource(Source.fromFile(path.toUri)) { source =>
+      parseYaml(source.mkString)
+    }
+
+  def parseYaml(contents: String): Either[String, Seq[ServerConfig]] = {
+    val parseResult = for {
+      json <- yaml.parser.parse(contents)
+      serverConfigs <- json.hcursor.downField("servers").as[List[ServerConfig]]
+    } yield serverConfigs
+
+    parseResult.leftMap(_.show)
+  }
+}

--- a/src/test/scala/io/flow/build/ServerConfigSpec.scala
+++ b/src/test/scala/io/flow/build/ServerConfigSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
 class ServerConfigSpec extends AnyFunSpec with Matchers {
-  it("parses server list") {
+  it("parses server list from valid yaml") {
     val yaml =
       """
         |# comments
@@ -25,5 +25,11 @@ class ServerConfigSpec extends AnyFunSpec with Matchers {
 
   it("fails to parse") {
     ServerConfig.parseYaml("not yaml") shouldBe Left("DecodingFailure at .servers: Missing required field")
+  }
+
+  it("when file does not exist") {
+    ServerConfig.parseFile(java.nio.file.Paths.get("/tmp/wibblywobblywonder.yaml")) shouldBe Left(
+      "/tmp/wibblywobblywonder.yaml (No such file or directory)",
+    )
   }
 }

--- a/src/test/scala/io/flow/build/ServerConfigSpec.scala
+++ b/src/test/scala/io/flow/build/ServerConfigSpec.scala
@@ -1,0 +1,29 @@
+package io.flow.build
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class ServerConfigSpec extends AnyFunSpec with Matchers {
+  it("parses server list") {
+    val yaml =
+      """
+        |# comments
+        |
+        |servers:
+        |  - name: catalog
+        |    host: http://localhost:7121
+        |  - name: billing
+        |    host: http://localhost:6071
+        |""".stripMargin
+    ServerConfig.parseYaml(yaml) shouldBe Right(
+      Seq(
+        ServerConfig("catalog", "http://localhost:7121"),
+        ServerConfig("billing", "http://localhost:6071"),
+      ),
+    )
+  }
+
+  it("fails to parse") {
+    ServerConfig.parseYaml("not yaml") shouldBe Left("DecodingFailure at .servers: Missing required field")
+  }
+}

--- a/src/test/scala/io/flow/proxy/ControllerSpec.scala
+++ b/src/test/scala/io/flow/proxy/ControllerSpec.scala
@@ -1,0 +1,36 @@
+package io.flow.proxy
+
+import io.apibuilder.spec.v0.models.Service
+import io.flow.build.{BuildConfig, ServerConfig}
+import io.flow.lint.Services
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class ControllerSpec extends AnyFunSpec with Matchers {
+  private val service: Service = Services.Base
+
+  private val resolveHost: Service => String = {
+    val buildConfig = BuildConfig(
+      protocol = "https",
+      domain = "api.flow.io",
+      productionServerConfigs = Seq(ServerConfig(name = service.name, host = "http://lint.me")),
+      output = java.nio.file.Paths.get("/tmp"),
+    )
+    val serviceHostResolver = ServiceHostResolver(Nil)
+    Controller.makeProductionHostProvider(buildConfig, serviceHostResolver)
+  }
+
+  describe("production host resolver") {
+    describe("when server config available") {
+      it("should use configured host") {
+        resolveHost(service) shouldBe "http://lint.me"
+      }
+    }
+
+    describe("when server config not available") {
+      it("should use constructed host name") {
+        resolveHost(service.copy(name = "foo")) shouldBe "https://foo.api.flow.io"
+      }
+    }
+  }
+}


### PR DESCRIPTION
The goal is to allow specification of the host to be used for specific servers. This is achieved by using (an optional) yaml configuration file with the same format of the one output. e.g.
```
# override the host values constructed by api-build program for these services
servers:
  - name: payment-gateway
    host: http://payment.payment
  - name: payment-request-bundle
    host: http://payment.payment
  - name: payment
    host: http://payment.payment
```
The file location is specified by parameter `--production-config <path>`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * YAML-based production server config to override service hosts.
  * CLI enhancements: production-config path, domain override, http-only flag, and command/build-type validation.
  * Production host resolution: prefers configured hosts, falls back to protocol+service+domain.

* **Chores**
  * Added JSON/YAML parsing libraries to enable config support.
  * Build config now surfaces production server configs.

* **Tests**
  * Unit tests for server-config YAML parsing and production host resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->